### PR TITLE
Fix #10

### DIFF
--- a/src/main/java/lilliputian/handlers/EntitySizeHandler.java
+++ b/src/main/java/lilliputian/handlers/EntitySizeHandler.java
@@ -380,7 +380,7 @@ public class EntitySizeHandler {
 		float size = EntitySizeUtil.getEntityScale(entity);
 
 		if (event.getSource() == DamageSource.FALL) {
-			event.setAmount(event.getAmount() * Math.min(MathHelper.sqrt(size), size));
+			event.setAmount(event.getAmount() / Math.min(MathHelper.sqrt(size), size));
 		} else {
 			event.setAmount(event.getAmount() / MathHelper.sqrt(size));
 		}
@@ -388,7 +388,7 @@ public class EntitySizeHandler {
 		if (event.getSource().getImmediateSource() != null) {
 			float attackerSize = EntitySizeUtil.getEntityScale(event.getSource().getImmediateSource());
 
-			event.setAmount(event.getAmount() * MathHelper.sqrt(size));
+			event.setAmount(event.getAmount() / MathHelper.sqrt(size));
 		}
 	}
 
@@ -429,7 +429,7 @@ public class EntitySizeHandler {
 			float entitySize = EntitySizeUtil.getEntityScale(entity);
 
 			event.setVolume(event.getVolume() * MathHelper.sqrt(entitySize));
-			event.setPitch(event.getPitch() * entitySize);
+			event.setPitch(event.getPitch() / entitySize);
 		}
 	}
 


### PR DESCRIPTION
Swaps the scaling so big entities will now take less fall damage and make lower pitched sounds.
Small entities now take more fall damage and make higher pitched sounds.

(I haven't tested this because I don't know how to compile this. It is a simple change though, so hopefully it's good!)