### PR TITLE
Skip Canceled RenderLivingEvent

### DIFF
--- a/src/main/java/lilliputian/handlers/RenderEntityHandler.java
+++ b/src/main/java/lilliputian/handlers/RenderEntityHandler.java
@@ -16,6 +16,10 @@ public class RenderEntityHandler {
 	
 	@SubscribeEvent
 	public static void renderEntityPre(RenderLivingEvent.Pre event) {
+		if (event.isCanceled()) {
+			return;
+		}
+
 		float scale = EntitySizeUtil.getEntityScale(event.getEntity());
 
 		GlStateManager.pushMatrix();
@@ -36,6 +40,10 @@ public class RenderEntityHandler {
 
 	@SubscribeEvent
 	public static void renderEntityNamePre(RenderLivingEvent.Specials.Pre event) {
+		if (event.isCanceled()) {
+			return;
+		}
+
 		float scale = EntitySizeUtil.getEntityScale(event.getEntity());
 
 		GlStateManager.pushMatrix();


### PR DESCRIPTION
If RenderLivingEvent's Pre events are canceled, the subsequent Post events are not called, causing stack overflows from unpopped matrices.